### PR TITLE
Simplifies the getArticleData function in timeline

### DIFF
--- a/helpers/image.js
+++ b/helpers/image.js
@@ -15,6 +15,11 @@ function formatImageUrl(url, size) {
   return format.concat(`?source=ftlabs&width=${size}`);
 }
 
+function resizeImageURL(url, size){
+  const parts = url.split('?');
+  return parts[0].concat(`?source=ftlabs&width=${size}`);
+}
+
 function checkUrl(url) {
   const ftcmsImageRegex = /^https?:\/\/(?:(?:www\.)?ft\.com\/cms|im\.ft-static\.com\/content\/images|com\.ft\.imagepublish\.(?:prod|upp-prod-eu|upp-prod-us)\.s3\.amazonaws\.com|prod-upp-image-read\.ft\.com)\/([a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12})/g;
   return ftcmsImageRegex.test(url);
@@ -31,4 +36,4 @@ function extractUUID(link) {
   return undefined;
 }
 
-module.exports = { formatImageUrl };
+module.exports = { formatImageUrl, resizeImageURL };

--- a/lib/fetchContent.js
+++ b/lib/fetchContent.js
@@ -305,6 +305,17 @@ function getArticle(uuid) {
 		});
 }
 
+function getArticles(uuids, params) {
+	return search(params).then(results => {
+		return results.sapiObj.results[0].results;
+	});
+}
+
+function constructUUIDsQuery(uuids){
+	let ids = uuids.map(id => `id:=\"${id}\"`);
+	return ids.join(' OR ');
+}
+
 function getRecentArticles(days, aspects, facets)
 {
 	const date = time.getDatetimeRange('days', days, 0);
@@ -659,6 +670,8 @@ module.exports = {
 	searchSequence,
 	searchFacetHistory,
 	getArticle,
+	getArticles,
 	getRecentArticles,
-	getArticleRelations
+	getArticleRelations,
+	constructUUIDsQuery
 };

--- a/lib/listService.js
+++ b/lib/listService.js
@@ -1,5 +1,4 @@
 const BigQuery = require("@google-cloud/bigquery");
-
 const listDBHelper = require("../helpers/listDB");
 
 const bigQuery = new BigQuery({
@@ -73,6 +72,9 @@ function positionData(list, position, days) {
       dateFrom,
       dateTo
     })
+  }).then(data => {
+    let listData = data[0];
+    return listData;
   });
 }
 

--- a/lib/timelineService.js
+++ b/lib/timelineService.js
@@ -1,6 +1,7 @@
 const listService = require("./listService");
 const fetchContent = require("./fetchContent");
 const { formatImageUrl } = require("../helpers/image");
+const { resizeImageURL } = require("../helpers/image");
 
 async function constructJSON() {
   let listData = await listService.positionData(
@@ -8,8 +9,7 @@ async function constructJSON() {
     0,
     7
   );
-  //   console.log(listData);
-  listData = listData[0];
+
   let startDate = new Date();
   startDate.setDate(startDate.getDate() - 7);
 
@@ -25,22 +25,21 @@ async function constructJSON() {
     },
     events: listData.map(object => {
       const entryDate = new Date(object.entry_timestamp.value);
-
       let event = {
         start_date: constructDateObject(entryDate),
         text: {
-          headline: articleData[object.content_id].title,
-          text: articleData[object.content_id].standfirst
+          headline: articleData[object.content_id].title.title,
+          text: articleData[object.content_id].summary.excerpt
         },
         media: {
-          url: articleData[object.content_id].mainImage
-            ? formatImageUrl(
-                articleData[object.content_id].mainImage.members[0],
+          url: articleData[object.content_id].images
+            ? resizeImageURL(
+                articleData[object.content_id].images[0].url,
                 800
               )
             : process.env.FT_LOGO,
-          thumbnail: formatImageUrl(
-            articleData[object.content_id].mainImage.members[0],
+          thumbnail: resizeImageURL(
+            articleData[object.content_id].images[0].url,
             200
           )
         }
@@ -57,10 +56,14 @@ async function constructJSON() {
 
 async function getArticleData(listData) {
   try {
-    const results = await Promise.all(
-      listData.map(element => fetchContent.getArticle(element.content_id))
-    );
-    return results;
+    const uuids = listData.map(element => element.content_id);
+    const params = {
+      queryString : fetchContent.constructUUIDsQuery(uuids),
+      maxResults: 100,
+      facets: { names: ['people', 'organisations', 'topics', 'genre'], maxElements: -1 },
+      aspects : ["audioVisual", "editorial", "images", "lifecycle", "location", "master", "metadata", "nature", "provenance", "summary", "title"],
+    };
+    return await fetchContent.getArticles(uuids, params);
   } catch (error) {
     throw new Error(error);
   }
@@ -79,8 +82,8 @@ function constructDateObject(date) {
 function createArticleObject(rawArticleData) {
   let articleData = {};
   rawArticleData.forEach(article => {
-    if (article.webUrl) {
-      articleData[article.webUrl.split("/").pop()] = article;
+    if (article.id) {
+      articleData[article.id] = article;
     }
   });
   return articleData;

--- a/lib/timelineService.js
+++ b/lib/timelineService.js
@@ -89,63 +89,15 @@ function createArticleObject(rawArticleData) {
   return articleData;
 }
 
-function annotationCount(articleData) {
-  let annotationsCount = [];
-  articleData.forEach(article => {
-    if (article.annotations) {
-      article.annotations.forEach(annotation => {
-        if (
-          annotationsCount.find(
-            existingAnnotation =>
-              existingAnnotation.name === annotation.prefLabel
-          )
-        ) {
-          annotationsCount = annotationsCount.map(
-            existingAnnotation =>
-              existingAnnotation.name === annotation.prefLabel
-                ? {
-                    name: existingAnnotation.name,
-                    count: existingAnnotation.count + 1,
-                    articles: [...existingAnnotation.articles, article]
-                  }
-                : existingAnnotation
-          );
-        } else {
-          annotationsCount = [
-            ...annotationsCount,
-            { name: annotation.prefLabel, count: 1, articles: [article] }
-          ];
-        }
-      });
-    }
-  });
-  return annotationsCount.sort((a, b) => a.count - b.count).reverse();
-}
-
-async function constructTopicJSON(topics) {
-  let listData = await listService.positionData(
-    "uk-homepage-top-stories",
-    [0, 1, 2],
-    12
-  );
-  listData = listData[0];
-  let articleData = await getArticleData(listData);
-  let annotationsCount = annotationCount(articleData);
-  annotationsCount = annotationsCount.filter(annotation =>
-    topics.includes(annotation.name)
-  );
-}
-
 async function simpleJSON() {
   let listData = await listService.positionData(
     "uk-homepage-top-stories",
     [0, 1, 2],
     2
   );
-  listData = listData[0];
   let articleData = await getArticleData(listData);
   return articleData.map((article, index) => {
-    publishHour = new Date(article.firstPublishedDate).getHours();
+    publishHour = new Date(article.lifecycle.initialPublishDateTime).getHours();
     if (publishHour > 12) {
       publishHour = `${publishHour - 12}pm`;
     } else {
@@ -159,11 +111,14 @@ async function simpleJSON() {
       article.firstArticle = false;
     }
 
-    article.image = article.mainImage
-      ? formatImageUrl(article.mainImage.members[0], 800)
+    article.image = article.images[0].url
+      ? resizeImageURL(article.images[0].url, 800)
       : process.env.FT_LOGO;
     return article;
   });
 }
 
-module.exports = { constructJSON, constructTopicJSON, simpleJSON };
+module.exports = {
+  constructJSON,
+  simpleJSON
+};

--- a/routes/timeline.js
+++ b/routes/timeline.js
@@ -20,10 +20,10 @@ router.get("/simple", async (req, res, next) => {
   }
 });
 
-
 router.get("/vertical", async (req, res, next) => {
   try {
-    const data = await timelineService.simpleJSON();
+    let data = await timelineService.simpleJSON();
+    data = data.splice(0,5);
     res.render("timeline/vertical", { data });
   } catch (error) {
     throw new Error(error);
@@ -48,12 +48,6 @@ router.get("/simpleData", async (req, res, next) => {
   } catch (error) {
     throw new Error(error);
   }
-});
-
-router.get("/topic", async (req, res, next) => {
-  const data = await timelineService.constructTopicJSON(["Brexit"]);
-
-  res.render("timeline/timelineTopic");
 });
 
 module.exports = router;

--- a/views/timeline/simple.hbs
+++ b/views/timeline/simple.hbs
@@ -14,11 +14,11 @@
             {{#each data}}
             {{#if firstArticle}}
             <div class="input active">
-                <span data-year="{{title}}" data-info="{{formatedDate}}"></span>
+                <span data-year="{{title.title}}" data-info="{{formatedDate}}"></span>
             </div>
             {{else}}
             <div class="input">
-                <span data-year="{{title}}" data-info="{{formatedDate}}"></span>
+                <span data-year="{{title.title}}" data-info="{{formatedDate}}"></span>
             </div>
             {{/if}}
             {{/each}}
@@ -27,10 +27,10 @@
             {{#each data}}
             {{#if firstArticle}}
             <p class="active">
-                {{title}}
+                {{title.title}}
             </p>
             {{else}}
-            <p>{{title}}</p>
+            <p>{{title.title}}</p>
             {{/if}}
             {{/each}}
         </div>

--- a/views/timeline/vertical.hbs
+++ b/views/timeline/vertical.hbs
@@ -31,7 +31,7 @@
                                         <div class="spot {{#if firstArticle}}first{{/if}}"></div>
                                     </div>
                                     <img src="{{image}}">
-                                    <p>{{title}}</p>
+                                    <p>{{title.title}}</p>
                                     <div class="sparkline">
                                         <p>
                                             -sparkline-
@@ -77,7 +77,6 @@
             </div>
         </div>
     </main>
-    <script>console.log('{{data}}');</script>
 </body>
 
 </html>


### PR DESCRIPTION
Updates the getArticleData function to use one SAPI request, rather than multiple requests.
Also creates a getArticles endpoint in fetchContent which can accept an array of uuids and return their SAPI data