### PR TITLE
[Feature] ignore item list

### DIFF
--- a/lib/searchAndContent.js
+++ b/lib/searchAndContent.js
@@ -597,6 +597,16 @@ function concertinaSortedLists( correlations, params={} ){
 // refactor into generic correlation a group selected from each article
 function correlateGroupInArticles( fnGetGroupFromArticle, articles, params={} ){
 
+  debug(`correlateGroupInArticles: params=${JSON.stringify(params)}`);
+
+  // should we ignore any group items when extracting the group of items from an article,
+  // such as 'PERSON:Donald Trump'
+
+  const ignoreItemList = ((params.hasOwnProperty('ignoreItemList'))? params.ignoreItemList : [])
+  .map( item => { return item.toLowerCase(); } );
+
+  debug(`correlateGroupInArticles: ignoreItemList=${JSON.stringify(ignoreItemList)}`);
+
 	const correlations = {
 		stats : {
 			numArticles     : articles.length,
@@ -627,13 +637,24 @@ function correlateGroupInArticles( fnGetGroupFromArticle, articles, params={} ){
 			pubdateEarliest = (article.publishedDate < pubdateEarliest)? article.publishedDate : pubdateEarliest;
 			pubdateLatest = (article.publishedDate > pubdateLatest)? article.publishedDate : pubdateLatest;
 
-			const group = fnGetGroupFromArticle(article);
+      // find all the matching items in the article, and filter out any we should ignore
+			let group = fnGetGroupFromArticle(article);
+
+      if (group.length > 0 && group[0] !== undefined) {
+        group = group.filter( item => {
+          return ! ignoreItemList.includes( item.toLowerCase() );
+        });
+      }
+
+      // debug( `correlateGroupInArticles: article: group=${JSON.stringify(group)}`);
+
 			if (group.length === 0
 				|| (group.length === 1 && group[0] === undefined)) {
 				correlations.stats.undefinedCount += 1;
 				correlations.stats.undefinedUuids.push(article.uuid);
 				return;
 			}
+
 
 			// basic counts of each item, and group uuids by item
 			group.forEach( item => {
@@ -692,6 +713,7 @@ function correlateMergedAnnotations( params = {}, articles=[] ){
 		groups : ['primaryThemes', 'abouts'],
 	}
 	const combinedParams = Object.assign({}, defaultParams, params);
+  debug(`correlateMergedAnnotations: combinedParams=${JSON.stringify(combinedParams)}`);
 	const targetGenres = combinedParams.genres;
 	// 	params=${JSON.stringify(params)},
 	// 	combinedParams=${JSON.stringify(combinedParams)}`);
@@ -844,6 +866,7 @@ function searchDeeperArticlesCapi(params={}){
 }
 
 function correlateDammit(params={}){
+  debug(`correlateDammit: params=${JSON.stringify(params)}`);
 	return searchDeeperArticlesCapi(params)
 	.then( sResult => {
 		if (sResult.hasOwnProperty('err')) {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "dotenv": "^2.0.0",
     "express": "^4.16.4",
     "express-enforces-ssl": "^1.1.0",
-    "express-handlebars": "^3.0.0",
+    "express-handlebars": "^3.0.2",
     "ffmpeg-static": "^2.4.0",
-    "hbs": "^4.0.1",
+    "hbs": "^4.0.3",
     "helmet": "^3.15.0",
     "is-uuid": "^1.0.2",
     "md5": "^2.2.1",
@@ -53,7 +53,7 @@
   "devDependencies": {
     "nock": "^9.6.1",
     "nodemon": "^1.18.7",
-    "proxyquire": "^2.0.1",
+    "proxyquire": "^2.1.0",
     "sinon": "^5.0.10"
   },
   "engines": {

--- a/routes/searchAndContent.js
+++ b/routes/searchAndContent.js
@@ -36,7 +36,7 @@ function constructSearchParamsFromRequest( urlParams={}, bodyParams={} ){
 		}
 	});
   // string list params
-  ['genres', 'groups'].forEach( name => {
+  ['genres', 'groups', 'ignoreItemList'].forEach( name => {
     if (urlParams.hasOwnProperty(name) && urlParams[name] !== "") {
       params[name] = urlParams[name].split(',');
     }
@@ -429,7 +429,8 @@ router.get('/display/:template', async (req, res, next) => {
        queryString : 'lastPublishDateTime:>2018-11-07T00:00:00Z and lastPublishDateTime:<2018-11-08T00:00:00Z',
        genres      : "News,Opinion",
        concertinaOverlapThreshold : 0.66,
-       groups      : 'primaryThemes,abouts' // also mentions,aboutsAndMentions
+       groups      : 'primaryThemes,abouts', // also mentions,aboutsAndMentions
+       ignoreItemList : '',
      }
      const copyQueryParams = Object.assign(req.query);
      Object.keys(defaultParams).forEach( param => {
@@ -440,6 +441,7 @@ router.get('/display/:template', async (req, res, next) => {
      });
 
      const combinedParams = constructSearchParamsFromRequest( copyQueryParams, defaultParams );
+     // debug(`/display/:template : combinedParams=${JSON.stringify(combinedParams)}`);
      const searchResponse = await searchAndContent.correlateDammit( combinedParams );
      const data = prepDisplayData( searchResponse, combinedParams );
      res.render(`searchAndContentExperiments/${template}`, {

--- a/views/searchAndContent.hbs
+++ b/views/searchAndContent.hbs
@@ -31,6 +31,7 @@
 			<li><a href="/searchAndContent/display/basic1">/searchAndContent/display/basic1</a></li>
 			<li><a href="/searchAndContent/display/basic2">/searchAndContent/display/basic2</a> (with added cliques and config params)</li>
 			<li><a href="/searchAndContent/display/basic3">/searchAndContent/display/basic3</a> (with added cliques and config params and context - way too much info to display neatly, but ...)</li>
+			<li><a href="/searchAndContent/display/basic4">/searchAndContent/display/basic4</a> (with added cliques and config params and context and ignoreItemList - way too much info to display neatly, but ...)</li>
 		</ul>
 
 		<h2>Some data endpoints combining SAPI v1 and CAPI v2, and summarising</h2>

--- a/views/searchAndContentExperiments/basic4.hbs
+++ b/views/searchAndContentExperiments/basic4.hbs
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<style>
+			.grouping {
+				font-weight:bold;
+				background-color: coral;
+			}
+			.blank_row {
+			    height: 30px !important; /* overwrites any other rules */
+			    background-color: #FFFFFF;
+			}
+			.name {
+				font-size: 130%;
+				/* white-space: nowrap; */
+			}
+			.names {
+				font-size: 150%;
+				/* white-space: nowrap; */
+				width: 40%;
+			}
+			.nowrap {
+				white-space: nowrap;
+			}
+			.articles {
+				width: 60%;
+				padding: 0;
+				margin: 0;
+				list-style: none;
+			}
+			.articles65 {
+				width: 65%;
+			}
+			.thumbnail {
+				width: 30%;
+			}
+			.thumbnail100 {
+				width: 100%;
+			}
+			.thumbnailcol {
+				width: 45%;
+			}
+			.thumbnails {
+				width: 10%;
+			}
+			.pubdate {
+				font-size: 75%;
+				font-style: italic;
+			}
+			.subannos {
+			  display: flex;
+			}
+			.subannos > div {
+			  flex: 1; /*grow*/
+			}
+
+			table {
+			    border-collapse: collapse;
+			    width: 100%;
+			}
+			tr {
+			    border-bottom: 1px solid #ccc;
+			}
+
+		</style>
+
+	</head>
+	<body>
+		<h1>searchAndContent experiments: correlations in article annotations, with overlaps, cliques, and context</h1>
+		<h2>based on {{context.numArticles}} articles, of which {{context.numArticlesInGenres}} articles in genres "{{context.genresString}}"</h2>
+		<p>
+			<form action="" method="get" class="params">
+				<label>queryString</label>=<textarea name="queryString" id="queryString" rows="3" cols="45">{{params.queryString}}</textarea>
+				<br>
+				<span class="nowrap"><label>genres</label> = <input type="text" name="genres" id="genres" value="{{params.genres}}" size="20"></span>
+				<span class="nowrap"><label>maxResults</label> = <input type="number" name="maxResults" id="maxResults" value="{{params.maxResults}}" size="3"></span>
+				<span class="nowrap"><label>maxDepth</label> = <input type="number" name="maxDepth" id="maxDepth" value="{{params.maxDepth}}" size="3"></span>
+				<span class="nowrap"><label>maxDurationMs</label> = <input type="number" name="maxDurationMs" id="maxDurationMs" value="{{params.maxDurationMs}}" size="5"></span>
+				<span class="nowrap"><label>concertinaOverlapThreshold</label> = <input type="number" name="concertinaOverlapThreshold" id="concertinaOverlapThreshold" value="{{params.concertinaOverlapThreshold}}" size="4" min="0" max="1.0" step="0.01"></span>
+				<span class="nowrap"><label>min2ndCliqueCount</label> = <input type="number" name="min2ndCliqueCount" id="min2ndCliqueCount" value="{{params.min2ndCliqueCount}}" size="4" min="1" max="100" step="1"></span>
+				<span class="nowrap"><label>min2ndCliqueProportion</label> = <input type="number" name="min2ndCliqueProportion" id="min2ndCliqueProportion" value="{{params.min2ndCliqueProportion}}" size="4" min="0" max="1.0" step="0.01"></span>
+				<span class="nowrap"><label>max2ndCliqueProportion</label> = <input type="number" name="max2ndCliqueProportion" id="max2ndCliqueProportion" value="{{params.max2ndCliqueProportion}}" size="4" min="0" max="1.0" step="0.01"></span>
+				<br>
+				<span class="nowrap"><label>groups</label> = <input type="text" name="groups" id="groups" value="{{params.groups}}" size="30"></span>
+				<br>
+				<span class="nowrap"><label>ignoreItemList</label> = <input type="text" name="ignoreItemList" id="ignoreItemList" value="{{params.ignoreItemList}}" size="50"></span>
+				<br>
+				<p>
+					Notes on the clumsy specification (and ignoring) of specific entities
+					<ul>
+						<li>
+							you can append a constraint in the <b>queryString</b> to reduce the number of matching articles.
+							<br>NB, you specify additional entities to match as follows, <i>using the plural ontology name, with the value in speech marks</i>
+							<ul>
+								<li>and <b>people</b>:<b>"</b>Donald Trump<b>"</b></li>
+								<li>and <b>topics</b>:<b>"</b>US midterm elections<b>"</b></li>
+								<li>and <b>organisations</b>:<b>"</b>Goldman Sachs Group<b>"</b></li>
+								<li>and <b>regions</b>:<b>"</b>UK<b>"</b> (NB, regions not locations)</li>
+							</ul>
+						</li>
+						<li>
+							you can ignore specific items in the aggregated views in the field, <b>ignoreItemList</b>,
+							<br>NB, you specify entities to ignore from the display as a CSV as follows, <i>using the singular ontology name, with no speech marks around the value</i>
+							<ul>
+								<li><b>person</b>:Donald Trump</li>
+								<li><b>topic</b>:US midterm elections</li>
+								<li><b>organisation</b>:Goldman Sachs Group</li>
+								<li><b>location</b>:UK</li>
+							</ul>
+						</li>
+					</ul>
+				</p>
+				<input type="submit" value="SEARCH and SUMMARISE!">
+			</form>
+		</p>
+		<div>
+			<ul>
+				{{#each data.groups}}
+				<li><a href="#{{this.name}}">{{ this.name }}</a></li>
+				{{/each}}
+			</ul>
+		</div>
+
+		<main class="centerPos">
+			<table>
+				{{#each data.groups}}
+					<tr id="{{this.name}}">
+						<td class="grouping" colspan="3">{{ this.name }}</td>
+					</tr>
+					{{#each this.byCount.topAnnotations }}
+						{{#if this.cliques.length}}
+							{{#each this.cliques}}
+								<tr>
+									<td class="names">
+										[ {{name}} ]<br><br>{{{ namesWithCountsBR }}}<br><br>
+									</td>
+									<td class="thumbnails">
+										{{#each this.articles}}
+											{{#if mainImage.thumbnailUrl}}
+												<img class="thumbnailcol" src="{{mainImage.thumbnailUrl}}">
+											{{/if}}
+										{{/each}}
+									</td>
+									<td class="articles">
+										<span class="articlecount">{{this.articles.length}}<span>
+										<ul>
+										{{#each this.articles}}
+											<li><a href="https://www.ft.com/content/{{uuid}}" target="_blank">{{title}}</a></li>
+										{{/each}}
+										</ul>
+									</td>
+								</tr>
+								<tr>
+									<td colspan="3">
+										<div class="subannos">
+											{{#each annosByTaxonomy}}
+												<div>
+												{{@key}}<br>
+												<ul>
+													{{#each this}}
+														<li>{{name}} ({{count}})</li>
+													{{/each}}
+												</ul>
+											</div>
+											{{/each}}
+										</div>
+									</td>
+								</tr>
+							{{/each}}
+						{{else}}
+							<tr>
+								<td class="names">
+									{{{ this.nameWithCountsBR }}}<br>
+								</td>
+								<td class="thumbnails">
+									{{#each this.articles}}
+										{{#if mainImage.thumbnailUrl}}
+											<img class="thumbnailcol" src="{{mainImage.thumbnailUrl}}">
+										{{/if}}
+									{{/each}}
+								</td>
+								<td class="articles">
+									<span class="articlecount">{{this.articles.length}}<span>
+									<ul>
+									{{#each this.articles}}
+										<li><a href="https://www.ft.com/content/{{uuid}}" target="_blank">{{title}}</a></li>
+									{{/each}}
+									</ul>
+								</td>
+							</tr>
+							<tr>
+								<td colspan="3">
+									<div class="subannos">
+										{{#each this.annosByTaxonomy}}
+											<div>
+											{{@key}}<br>
+											<ul>
+												{{#each this}}
+													<li>{{name}} ({{count}})</li>
+												{{/each}}
+											</ul>
+										</div>
+										{{/each}}
+									</div>
+								</td>
+							</tr>
+						{{/if}}
+				  {{/each}}
+					{{#if byCount.annotationsBubblingUnder.length}}
+					<tr>
+					<td colspan="3">
+						<br>... bubbling under (with just one article each)<br>
+						{{#each byCount.annotationsBubblingUnder}}
+						{{{this}}},
+						{{/each}}
+					</td>
+				</tr>
+					{{/if}}
+
+					<tr class="blank_row"></tr>
+				{{/each}}
+			</table>
+
+
+		</main>
+	</body>
+</html>


### PR DESCRIPTION
## Description
This allows the plucky data explorer to filter out specific entities from the aggregated display, e.g. when you have constrained the search to include a particular person, and yet you don;t want that person to appear in every aggregation.

A description of how to use and specify the params is included in the new view, /searchAndContent/display/basic4

## Implementation
is basically a new search param, and a small bit of code to react to its presence
