### PR TITLE
stop leaking the apiKey in err message

### DIFF
--- a/lib/searchAndContent.js
+++ b/lib/searchAndContent.js
@@ -914,8 +914,8 @@ function correlateDammit(params={}){
 		};
 	})
 	.catch( err => {
-    throw new Error(`correlateDammit: ${err.message}`);
-		// return { err: 'correlateDammit: ' + err.message };
+    const message = err.message.replace( /apiKey=[a-zA-z0-9\-]+/g, 'apiKey=...');
+    throw new Error(`correlateDammit: ${message}`);
 	})
 	;
 }


### PR DESCRIPTION
## Description
// A description of the feature/issue

If the SAPI url is invalid or the service is down, the err.message reveals the apiKey.

## Implementation

replace the apiKey with ...

## Screenshot
//If the feature is visual. Or a before/after in case of an update

## .env changes
//Required variables to run locally -- the values should be saved in LastPass

## Additional requirements
//Required modules or properties to run locally (e.g. Needs to run `npm i` again, or CAPI key needed a new property)

_[Optional] A funny image or GIF that relates to the bug/feature at hand._
